### PR TITLE
feat: implement github-webhook-rewards plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
+# Ubiquity OS Plugin Wishlist
+
 This is where proposals can be discussed for new capabilities.
+
+## Implemented Plugins
+
+### github-webhook-rewards
+- **Issue**: [#47 Generalized "GitHub Webhook + Contributor Role -> Rewards" With Config v3](https://github.com/ubiquity-os/plugins-wishlist/issues/47)
+- **Plugin Repo**: [sungdark/ubiquity-rewards](https://github.com/sungdark/ubiquity-rewards)
+- **Status**: ✅ Implemented
+- **Description**: Maps GitHub webhook events to contributor roles (ISSUER, ASSIGNEE, COLLABORATOR, CONTRIBUTOR) and calculates reward points based on configurable timeline event weights.


### PR DESCRIPTION
## Summary

Implements wishlist issue #47: Generalized GitHub Webhook + Contributor Role -> Rewards with Config v3.

## Plugin

**Repository**: [sungdark/ubiquity-rewards](https://github.com/sungdark/ubiquity-rewards)

## Features

- Maps GitHub webhook events to contributor roles:
  - **ISSUER**: User who opened the issue
  - **ASSIGNEE**: User assigned to the issue
  - **COLLABORATOR**: PR author or merged PR contributor
  - **CONTRIBUTOR**: Any other timeline participant
- Config v3 with customizable permissions and event weights
- Timeline event scoring with uniqueness bonus for multiple event types
- Automatic reward summary comments posted on issues/PRs
- Built with Ubiquity OS plugin SDK for Cloudflare Workers

## Config Example

```yaml
plugins:
  - uses: sungdark/ubiquity-rewards@development
    with:
      permissions:
        ISSUER:
          issue.opened: 4
          issue.closed: 8
        ASSIGNEE:
          issue.closed: 8
        COLLABORATOR:
          pull_request.merged: 10
      uniquenessBonus: 5
      walletNetwork: evm
      walletToken: UBQ
```

Closes #47