### PR TITLE
docs: add alternate Config Protection implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 This is where proposals can be discussed for new capabilities.
+
+## Implemented Plugins
+
+### Config Protection
+
+- Bounty: `#30`
+- Repository: https://github.com/enlohhy/config-protection
+- Status: alternate implementation published and locally verified
+
+This plugin protects UbiquityOS configuration files from unauthorized edits on the default branch.
+It checks repository admin access, verifies organization billing-manager role membership, and restores
+only the protected config files touched by an unauthorized push so unrelated files from the same push
+are preserved.


### PR DESCRIPTION
Resolves #30\n\n## Summary\n- add an Implemented Plugins entry for the alternate Config Protection implementation\n- link to https://github.com/enlohhy/config-protection\n- note the safer revert behavior and role-checking approach\n\n## Why this implementation is worth considering\n- restores only protected config files touched by an unauthorized push, preserving unrelated files from the same push\n- checks billing-manager access via organization role membership rather than assuming the regular membership API exposes that role\n- includes focused tests for authorized writes, unauthorized writes, and partial revert behavior\n\n## Local verification\n- npm test -- --runInBand\n- npm run build