### PR TITLE
feat: Config Protection Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
+# Plugins Wishlist
+
 This is where proposals can be discussed for new capabilities.
+
+## Implemented Plugins
+
+| Plugin | Bounty | Repository | Description |
+|--------|--------|------------|-------------|
+| Config Protection | $75 | [nguyenlnp/config-protection](https://github.com/nguyenlnp/config-protection) | Protects UbiquityOS configuration files from unauthorized modifications. Only admins and billing managers can modify config files; unauthorized changes are automatically reverted. |
+
+### Config Protection
+
+**Resolves:** #30
+
+**Configurable protected paths** — defaults to all common UbiquityOS config file locations (`.ubiquity-os.config.yml`, `.github/ubiquity-os.config.yml`, etc.).
+
+**Configurable allowed roles** — defaults to `admin` and `billing_manager`. The plugin checks repository collaborator permissions and organization membership to verify authorization.
+
+**Automatic revert** — when an unauthorized user modifies a protected config file on the default branch, the commit is immediately reverted via the Git Data API. The revert commit message identifies the unauthorized user and original commit SHA.
+
+**Default branch only** — only monitors pushes to the default branch, so feature branch changes are not affected.
+
+**Case-insensitive matching** — catches config files regardless of casing (e.g., `.UBIQUITY-OS.CONFIG.YML`).
+
+**Billing manager detection** — checks org-level `billing_manager` role via the GitHub membership API, as this is an organization-level permission rather than a repository-level one.


### PR DESCRIPTION
## Config Protection Plugin

Resolves #30

### Plugin Repository
https://github.com/nguyenlnp/config-protection

### How It Works
1. **Listens for push events** on the default branch
2. **Detects config file changes** by checking if protected file paths (e.g., `.ubiquity-os.config.yml`) were modified
3. **Verifies committer permissions** — checks if the user has `admin` or `billing_manager` role via GitHub collaborator permission API and org membership API
4. **Auto-reverts unauthorized changes** — if the committer lacks proper authorization, the commit is immediately reverted via the Git Data API

### Configuration

| Setting | Type | Default | Description |
|---------|------|---------|-------------|
| `protectedConfigPaths` | `string[]` | `.ubiquity-os.config.yml`, `.ubiquity-os.config.yaml`, `ubiquity-os.config.yml`, `ubiquity-os.config.yaml`, `.github/ubiquity-os.config.yml`, `.github/ubiquity-os.config.yaml` | List of config file paths to protect |
| `allowedRoles` | `string[]` | `admin`, `billing_manager` | Roles allowed to modify config files |

### Key Features
- **Configurable protected paths** — defaults to all common UbiquityOS config file locations
- **Configurable allowed roles** — defaults to `admin` and `billing_manager`
- **Automatic revert** — unauthorized commits are immediately reverted via Git Data API
- **Default branch only** — only monitors pushes to the default branch
- **Case-insensitive matching** — catches config files regardless of casing
- **Billing manager detection** — checks org-level billing_manager role via membership API
- **Safe-by-default** — on permission check errors, denies access (fail-closed)

### Technical Implementation
- Built with TypeScript + UbiquityOS Plugin SDK
- Uses `@sinclair/typebox` for runtime settings validation
- Uses GitHub REST API for permission checking (repos.getCollaboratorPermissionLevel, orgs.getMembershipForUser)
- Revert creates a new commit with the parent tree, effectively undoing the unauthorized change
- The revert commit message identifies the unauthorized user and original commit SHA